### PR TITLE
Features/h3vr directory finder

### DIFF
--- a/src/TNHTweaker-UI.Common/Helpers/H3VrHelper.cs
+++ b/src/TNHTweaker-UI.Common/Helpers/H3VrHelper.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Win32;
+using System;
 using System.IO;
 using TNHTweaker_UI.Common.Interfaces;
 
@@ -9,17 +10,25 @@ namespace TNHTweaker_UI.Common.Helpers
     /// </summary>
     public class H3VrHelper : IH3VrHelper
     {
+        private const string h3vrRegistryPath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 450540";
+
         public DirectoryInfo FindH3VrDirectory()
         {
-            throw new NotImplementedException();
+            RegistryKey key = Registry.LocalMachine.OpenSubKey(h3vrRegistryPath);
+            if (key != null)
+            {
+                return new DirectoryInfo(key.GetValue("InstallLocation").ToString());
+            }
+            return null;
         }
 
         public bool IsTakeAndHoldTweakerInstalled()
         {
             var h3VrDirectory = FindH3VrDirectory();
             if (h3VrDirectory == null)
+            {
                 return false;
-
+            }
             return true;
         }
     }

--- a/src/TNHTweaker-UI.Common/Helpers/H3VrHelper.cs
+++ b/src/TNHTweaker-UI.Common/Helpers/H3VrHelper.cs
@@ -1,6 +1,7 @@
-﻿using Microsoft.Win32;
-using System;
+﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using Microsoft.Win32;
 using TNHTweaker_UI.Common.Interfaces;
 
 namespace TNHTweaker_UI.Common.Helpers
@@ -10,26 +11,107 @@ namespace TNHTweaker_UI.Common.Helpers
     /// </summary>
     public class H3VrHelper : IH3VrHelper
     {
-        private const string h3vrRegistryPath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 450540";
+        private const string H3VrRegistryPath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 450540";
+        private const string CustomCharactersFolderName = "CustomCharacters";
+        private const string IconIdsFileName = "IconIDs.txt";
+        private const string ObjectIdsFileName = "ObjectIDs.txt";
+        private const string SosigIdsFileName = "SosigIDs.txt";
 
         public DirectoryInfo FindH3VrDirectory()
         {
-            RegistryKey key = Registry.LocalMachine.OpenSubKey(h3vrRegistryPath);
-            if (key != null)
-            {
-                return new DirectoryInfo(key.GetValue("InstallLocation").ToString());
-            }
-            return null;
+            var key = Registry.LocalMachine.OpenSubKey(H3VrRegistryPath);
+            return key != null
+                ? new DirectoryInfo(key.GetValue("InstallLocation").ToString())
+                : null;
         }
 
-        public bool IsTakeAndHoldTweakerInstalled()
+        public DirectoryInfo FindTakeAndHoldTweakerCustomCharactersDirectory(string h3VrPath = "")
         {
-            var h3VrDirectory = FindH3VrDirectory();
+            var h3VrDirectory = FindH3VrDirectory(h3VrPath);
             if (h3VrDirectory == null)
             {
-                return false;
+                return null;
             }
-            return true;
+
+            var customCharacterFolderPath = h3VrDirectory.GetDirectories(CustomCharactersFolderName);
+            return customCharacterFolderPath.Any()
+                ? customCharacterFolderPath.First()
+                : null;
+        }
+
+        public List<string> ReadTakeAndHoldIconIds(string h3VrPath = "")
+        {
+            var h3VrDirectory = FindH3VrDirectory(h3VrPath);
+            return h3VrDirectory == null
+                ? new List<string>()
+                : ReadIdFile(Path.Combine(h3VrDirectory.FullName, CustomCharactersFolderName, IconIdsFileName));
+        }
+
+        public List<string> ReadTakeAndHoldObjectIds(string h3VrPath = "")
+        {
+            var h3VrDirectory = FindH3VrDirectory(h3VrPath);
+            return h3VrDirectory == null
+                ? new List<string>()
+                : ReadIdFile(Path.Combine(h3VrDirectory.FullName, CustomCharactersFolderName, ObjectIdsFileName));
+        }
+
+        public List<string> ReadTakeAndHoldSosigIds(string h3VrPath = "")
+        {
+            var h3VrDirectory = FindH3VrDirectory(h3VrPath);
+            return h3VrDirectory == null
+                ? new List<string>()
+                : ReadIdFile(Path.Combine(h3VrDirectory.FullName, CustomCharactersFolderName, SosigIdsFileName));
+        }
+
+        /// <summary>
+        /// Reads an ID's text file and returns a list of the ID's found in the file.
+        /// </summary>
+        /// <param name="pathToFile">The full path to the text file to read.</param>
+        /// <returns>A list of ID's. Or an empty list if the file was not found or empty.</returns>
+        private List<string> ReadIdFile(string pathToFile)
+        {
+            var ids = new List<string>();
+            try
+            {
+                var readLines = File.ReadAllLines(pathToFile);
+                var filteredIds = readLines.Where(line => !string.IsNullOrEmpty(line.Trim()) && !line.Trim().StartsWith("#")).ToArray(); //Remove empty lines and commented lines.
+                ids.AddRange(filteredIds);
+            }
+            catch (IOException)
+            {
+                return ids;
+            }
+            return ids;
+        }
+
+        /// <summary>
+        /// Attempt to locate the H3VR directory on this system.
+        /// Either uses the given <paramref name="h3VrPath"/> or the <see cref="FindH3VrDirectory"/> method.
+        /// Also checks if either of these directories exist.
+        /// </summary>
+        /// <param name="h3VrPath">The path to the H3VR directory that is set directly instead of finding it via the registry.</param>
+        /// <returns>A <see cref="DirectoryInfo"/> instance with information about the H3VR installation directory. Or <c>null</c> if it could not be found.</returns>
+        private DirectoryInfo FindH3VrDirectory(string h3VrPath)
+        {
+            DirectoryInfo h3VrDirectory;
+            if (string.IsNullOrEmpty(h3VrPath))
+            {
+                h3VrDirectory = FindH3VrDirectory();
+                if (h3VrDirectory == null || !h3VrDirectory.Exists)
+                {
+                    return null;
+                }
+            }
+            else
+            {
+                h3VrDirectory = new DirectoryInfo(h3VrPath);
+                if (!h3VrDirectory.Exists)
+                {
+                    return null;
+                }
+            }
+
+            return h3VrDirectory;
         }
     }
 }

--- a/src/TNHTweaker-UI.Common/Helpers/H3VrHelper.cs
+++ b/src/TNHTweaker-UI.Common/Helpers/H3VrHelper.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.IO;
+using TNHTweaker_UI.Common.Interfaces;
+
+namespace TNHTweaker_UI.Common.Helpers
+{
+    /// <summary>
+    /// Implementation of the <see cref="IH3VrHelper"/> interface.
+    /// </summary>
+    public class H3VrHelper : IH3VrHelper
+    {
+        public DirectoryInfo FindH3VrDirectory()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool IsTakeAndHoldTweakerInstalled()
+        {
+            var h3VrDirectory = FindH3VrDirectory();
+            if (h3VrDirectory == null)
+                return false;
+
+            return true;
+        }
+    }
+}

--- a/src/TNHTweaker-UI.Common/Interfaces/IH3VrHelper.cs
+++ b/src/TNHTweaker-UI.Common/Interfaces/IH3VrHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 
 namespace TNHTweaker_UI.Common.Interfaces
 {
@@ -14,10 +15,32 @@ namespace TNHTweaker_UI.Common.Interfaces
         DirectoryInfo FindH3VrDirectory();
 
         /// <summary>
-        /// Checks if the take and hold tweaker plugin for BepInEx is installed on this system.
-        /// Can only return <c>true</c> if <see cref="FindH3VrDirectory"/> returns a valid path to check.
+        /// Attempt to find the Take and Hold Tweaker Custom Character directory.
+        /// Requires <see cref="FindH3VrDirectory"/> to return the installation path for H3VR.
         /// </summary>
-        /// <returns><C>true</C> if the Take and Hold Tweaker plugin in present, <c>false</c> otherwise.</returns>
-        bool IsTakeAndHoldTweakerInstalled();
+        /// <param name="h3VrPath">Optional direct path to the H3VR directory. Use this if <see cref="FindH3VrDirectory"/> cannot find the installation path.</param>
+        /// <returns>A <see cref="DirectoryInfo"/> object with information about the Take and Hold Tweaker Custom Characters directory, or <c>null</c> if the H3VR or custom characters directory was not found.</returns>
+        DirectoryInfo FindTakeAndHoldTweakerCustomCharactersDirectory(string h3VrPath = "");
+
+        /// <summary>
+        /// Reads the list of Icon ID's of the Take and Hold game mode.
+        /// </summary>
+        /// <param name="h3VrPath">Optional direct path to the H3VR directory. Use this if <see cref="FindH3VrDirectory"/> cannot find the installation path.</param>
+        /// <returns>A list of Icon ID's. Or an empty list if the file was not found or empty.</returns>
+        List<string> ReadTakeAndHoldIconIds(string h3VrPath = "");
+
+        /// <summary>
+        /// Reads the list of Object ID's of the Take and Hold game mode.
+        /// </summary>
+        /// <param name="h3VrPath">Optional direct path to the H3VR directory. Use this if <see cref="FindH3VrDirectory"/> cannot find the installation path.</param>
+        /// <returns>A list of Object ID's. Or an empty list if the file was not found or empty.</returns>
+        List<string> ReadTakeAndHoldObjectIds(string h3VrPath = "");
+
+        /// <summary>
+        /// Reads the list of Sosig ID's of the Take and Hold game mode.
+        /// </summary>
+        /// <param name="h3VrPath">Optional direct path to the H3VR directory. Use this if <see cref="FindH3VrDirectory"/> cannot find the installation path.</param>
+        /// <returns>A list of Sosig ID's. Or an empty list if the file was not found or empty.</returns>
+        List<string> ReadTakeAndHoldSosigIds(string h3VrPath = "");
     }
 }

--- a/src/TNHTweaker-UI.Common/Interfaces/IH3VrHelper.cs
+++ b/src/TNHTweaker-UI.Common/Interfaces/IH3VrHelper.cs
@@ -1,0 +1,23 @@
+﻿using System.IO;
+
+namespace TNHTweaker_UI.Common.Interfaces
+{
+    /// <summary>
+    /// Interface that describes helper functions for working with the H3VR game and directories.
+    /// </summary>
+    public interface IH3VrHelper
+    {
+        /// <summary>
+        /// Attempt to find the directory on the local system where H3VR is installed.
+        /// </summary>
+        /// <returns>A <see cref="DirectoryInfo"/> object with information about the H3VR location or <c>null</c> if the H3VR installation was not found.</returns>
+        DirectoryInfo FindH3VrDirectory();
+
+        /// <summary>
+        /// Checks if the take and hold tweaker plugin for BepInEx is installed on this system.
+        /// Can only return <c>true</c> if <see cref="FindH3VrDirectory"/> returns a valid path to check.
+        /// </summary>
+        /// <returns><C>true</C> if the Take and Hold Tweaker plugin in present, <c>false</c> otherwise.</returns>
+        bool IsTakeAndHoldTweakerInstalled();
+    }
+}

--- a/src/TNHTweaker-UI.Common/TNHTweaker-UI.Common.csproj
+++ b/src/TNHTweaker-UI.Common/TNHTweaker-UI.Common.csproj
@@ -5,4 +5,8 @@
     <RootNamespace>TNHTweaker_UI.Common</RootNamespace>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/TNHTweaker-UI.Common/TNHTweaker-UI.Common.csproj
+++ b/src/TNHTweaker-UI.Common/TNHTweaker-UI.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>TNHTweaker_UI.Common</RootNamespace>
   </PropertyGroup>
 

--- a/src/TNHTweaker-UI.WPF/MainWindow.xaml.cs
+++ b/src/TNHTweaker-UI.WPF/MainWindow.xaml.cs
@@ -1,27 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using TNHTweaker_UI.Common;
-using TNHTweaker_UI.Common.Helpers;
-
-namespace TNHTweaker_UI.WPF
+﻿namespace TNHTweaker_UI.WPF
 {
     /// <summary>
     /// Interaction logic for MainWindow.xaml
     /// </summary>
-    public partial class MainWindow : Window
+    public partial class MainWindow
     {
         public MainWindow()
         {

--- a/src/TNHTweaker-UI.WPF/MainWindow.xaml.cs
+++ b/src/TNHTweaker-UI.WPF/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -12,6 +13,8 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using TNHTweaker_UI.Common;
+using TNHTweaker_UI.Common.Helpers;
 
 namespace TNHTweaker_UI.WPF
 {


### PR DESCRIPTION
Added a way for the the application to find the H3VR installation directory on a system using the registry.
While still having other methods take an optional path in case the user has entered their H3VR installation directory path if it could not be found automatically.

Also added methods for reading the icon, object and sosig ID files that the Take and Hold tweaker mod generates.
These will be used later for overriding weapon spawns, or defining patrol and defense enemies.