### PR TITLE
Fixed a few issues with converting from the old format

### DIFF
--- a/src/TNHTweaker-UI.BusinessLogic/CharacterConverter.cs
+++ b/src/TNHTweaker-UI.BusinessLogic/CharacterConverter.cs
@@ -62,7 +62,7 @@ namespace TNHTweaker_UI.BusinessLogic
         private static WeaponDefinition ConvertWeaponDefinition(OldFormat.WeaponDefinition oldWeaponDefinition)
         {
             if (oldWeaponDefinition == null)
-                return null;
+                return new WeaponDefinition(); //Just return a new empty instance otherwise the character won't load even though the respective "HasPrimaryX" property is false.
 
             var newWeaponDefinition = new WeaponDefinition
             {
@@ -90,7 +90,9 @@ namespace TNHTweaker_UI.BusinessLogic
                 ExcludedModes = oldObjectTableDefinition.ExcludeModes,
                 Features = oldObjectTableDefinition.Features,
                 FeedOptions = oldObjectTableDefinition.FeedOptions,
-                IconName = oldObjectTableDefinition.Icon,
+                IconName = oldObjectTableDefinition.Icon.StartsWith("@")
+                    ? oldObjectTableDefinition.Icon.Replace("@", string.Empty) //If people use an @ sign for icons they do not load in the new format so remove them.
+                    : oldObjectTableDefinition.Icon,
                 IdOverride = oldObjectTableDefinition.IdOverride,
                 IsBlanked = oldObjectTableDefinition.IsBlanked,
                 MaxAmmoCapacity = oldObjectTableDefinition.MaxAmmoCapacity,

--- a/src/TNHTweaker-UI.CustomCharacterConverter/ViewModels/MainWindowViewModel.cs
+++ b/src/TNHTweaker-UI.CustomCharacterConverter/ViewModels/MainWindowViewModel.cs
@@ -127,11 +127,16 @@ namespace TNHTweaker_UI.CustomCharacterConverter.ViewModels
 
             var convertedCharacterJson = _newCharacterSerializer.WriteCharacterToString(convertedCharacter);
             var directoryPath = new FileInfo(CharacterFilePath).DirectoryName;
+            if (directoryPath == null)
+            {
+                ConversionStatusLog = $"The path at: \"{CharacterFilePath}\" doesn't seem to exist";
+                return;
+            }
 
             try
             {
                 File.WriteAllText(Path.Combine(directoryPath, "convertedCharacter.json"), convertedCharacterJson);
-                ConversionStatusLog = $"The custom character was successfully converted and written to: \"{CharacterFilePath}\"";
+                ConversionStatusLog = $"The custom character was successfully converted and written to: \"{Path.Combine(directoryPath, "convertedCharacter.json")}\"";
 
                 //Reset values.
                 _loadedCharacter = null;


### PR DESCRIPTION
If any of the starter weapon definitions was not filled in the new format would contain a null value, which causes an error in-game.